### PR TITLE
Allow other addresses than the keyper set to broadcast eon keys

### DIFF
--- a/src/IKeyperSet.sol
+++ b/src/IKeyperSet.sol
@@ -11,4 +11,6 @@ interface IKeyperSet {
     function getMembers() external view returns (address[] memory);
 
     function getThreshold() external view returns (uint64);
+
+    function isAllowedToBroadcastEonKey(address a) external view returns (bool);
 }

--- a/src/KeyBroadcastContract.sol
+++ b/src/KeyBroadcastContract.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.20;
 
 import "src/IKeyBroadcastContract.sol";
 import "src/IKeyperSetManager.sol";
+import "src/IKeyperSet.sol";
 
 contract KeyBroadcastContract is IKeyBroadcastContract {
     mapping(uint64 => bytes) private keys;
-    address private keyperSetManagerAddress;
+    IKeyperSetManager private keyperSetManager;
 
-    constructor(address _keyperSetManagerAddress) {
-        keyperSetManagerAddress = _keyperSetManagerAddress;
+    constructor(address keyperSetManagerAddress) {
+        keyperSetManager = IKeyperSetManager(keyperSetManagerAddress);
     }
 
     function broadcastEonKey(uint64 eon, bytes memory key) external {
@@ -20,8 +21,8 @@ contract KeyBroadcastContract is IKeyBroadcastContract {
             revert AlreadyHaveKey();
         }
         if (
-            msg.sender !=
-            IKeyperSetManager(keyperSetManagerAddress).getKeyperSetAddress(eon)
+            !IKeyperSet(keyperSetManager.getKeyperSetAddress(eon))
+                .isAllowedToBroadcastEonKey(msg.sender)
         ) {
             revert NotAllowed();
         }

--- a/src/KeyperSet.sol
+++ b/src/KeyperSet.sol
@@ -10,6 +10,7 @@ contract KeyperSet is IKeyperSet, Ownable {
     bool finalized;
     address[] members;
     uint64 threshold;
+    address broadcaster;
 
     function isFinalized() external view returns (bool) {
         return finalized;
@@ -47,7 +48,20 @@ contract KeyperSet is IKeyperSet, Ownable {
         threshold = _threshold;
     }
 
+    function setKeyBroadcaster(address _broadcaster) public onlyOwner {
+        if (finalized) {
+            revert AlreadyFinalized();
+        }
+        broadcaster = _broadcaster;
+    }
+
     function setFinalized() public onlyOwner {
         finalized = true;
+    }
+
+    function isAllowedToBroadcastEonKey(
+        address a
+    ) external view returns (bool) {
+        return a == broadcaster;
     }
 }

--- a/test/KeyBroadcastContract.t.sol
+++ b/test/KeyBroadcastContract.t.sol
@@ -12,19 +12,26 @@ contract KeyBroadcastTest is Test {
     KeyperSetManager public keyperSetManager;
     KeyperSet public keyperSet0;
     KeyperSet public keyperSet1;
+    address public broadcaster0;
+    address public broadcaster1;
 
     event EonKeyBroadcast(uint64 eon, bytes key);
 
     function setUp() public {
+        broadcaster0 = address(1);
+        broadcaster1 = address(2);
+
         keyperSetManager = new KeyperSetManager();
         keyBroadcastContract = new KeyBroadcastContract(
             address(keyperSetManager)
         );
         keyperSet0 = new KeyperSet();
+        keyperSet0.setKeyBroadcaster(broadcaster0);
         keyperSet0.setFinalized();
         keyperSetManager.addKeyperSet(100, address(keyperSet0));
 
         keyperSet1 = new KeyperSet();
+        keyperSet1.setKeyBroadcaster(broadcaster1);
         keyperSet1.setFinalized();
         keyperSetManager.addKeyperSet(200, address(keyperSet1));
     }
@@ -32,24 +39,24 @@ contract KeyBroadcastTest is Test {
     function testBroadcastEonKeyEmpty() public {
         vm.expectRevert(InvalidKey.selector);
         bytes memory key = bytes("");
-        vm.prank(address(keyperSet1));
+        vm.prank(broadcaster1);
         keyBroadcastContract.broadcastEonKey(1, key);
     }
 
     function testBroadcastEonKeyNotAllowed() public {
         vm.expectRevert(NotAllowed.selector);
         bytes memory key = bytes("foo bar");
-        vm.prank(address(keyperSet1));
+        vm.prank(broadcaster1);
         keyBroadcastContract.broadcastEonKey(0, key);
     }
 
     function testBroadcastEonKeyDuplicate() public {
         bytes memory key = bytes("foo bar");
-        vm.prank(address(keyperSet1));
+        vm.prank(broadcaster1);
         keyBroadcastContract.broadcastEonKey(1, key);
 
         vm.expectRevert(AlreadyHaveKey.selector);
-        vm.prank(address(keyperSet1));
+        vm.prank(broadcaster1);
         keyBroadcastContract.broadcastEonKey(1, key);
     }
 
@@ -57,13 +64,13 @@ contract KeyBroadcastTest is Test {
         vm.expectEmit(address(keyBroadcastContract));
         bytes memory key = bytes("foo bar");
         emit EonKeyBroadcast(1, key);
-        vm.prank(address(keyperSet1));
+        vm.prank(broadcaster1);
         keyBroadcastContract.broadcastEonKey(1, key);
     }
 
     function testGetEonKey() public {
         assertEq(keyBroadcastContract.getEonKey(1), bytes(""));
-        vm.prank(address(keyperSet1));
+        vm.prank(broadcaster1);
         keyBroadcastContract.broadcastEonKey(1, bytes("foo bar"));
         assertEq(keyBroadcastContract.getEonKey(1), bytes("foo bar"));
     }


### PR DESCRIPTION
Previously we only allowed the keyper set contract to broadcast eon keys. We now allow a signle configurable address to broadcast the eon key. This simplifies the setup later and allows us to use a multisig contract for broadcasting eon keys.