### PR TITLE
Implement sequencer contract

### DIFF
--- a/src/ISequencer.sol
+++ b/src/ISequencer.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+error InsufficientFee();
+
+interface ISequencer {
+    function submitEncryptedTransaction(
+        uint64 eon,
+        bytes32 identityPrefix,
+        bytes memory encryptedTransaction,
+        uint256 gasLimit
+    ) external payable;
+
+    function submitDecryptionProgress(bytes memory message) external;
+
+    event TransactionSubmitted(
+        uint64 eon,
+        bytes32 identityPrefix,
+        address sender,
+        bytes encryptedTransaction,
+        uint256 gasLimit
+    );
+    event DecryptionProgressSubmitted(bytes message);
+}

--- a/src/Sequencer.sol
+++ b/src/Sequencer.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "src/ISequencer.sol";
+
+contract Sequencer is ISequencer {
+    function submitEncryptedTransaction(
+        uint64 eon,
+        bytes32 identityPrefix,
+        bytes memory encryptedTransaction,
+        uint256 gasLimit
+    ) external payable {
+        if (msg.value < block.basefee * gasLimit) {
+            revert InsufficientFee();
+        }
+
+        emit TransactionSubmitted(
+            eon,
+            identityPrefix,
+            msg.sender,
+            encryptedTransaction,
+            gasLimit
+        );
+    }
+
+    function submitDecryptionProgress(bytes memory message) external {
+        emit DecryptionProgressSubmitted(message);
+    }
+}

--- a/test/Sequencer.t.sol
+++ b/test/Sequencer.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/ISequencer.sol";
+import "../src/Sequencer.sol";
+
+contract SequencerTest is Test {
+    Sequencer public sequencer;
+
+    event TransactionSubmitted(
+        uint64 eon,
+        bytes32 identityPrefix,
+        address sender,
+        bytes encryptedTransaction,
+        uint256 gasLimit
+    );
+    event DecryptionProgressSubmitted(bytes message);
+
+    function setUp() public {
+        sequencer = new Sequencer();
+    }
+
+    function testSubmitTransaction() public {
+        uint64 eon = 5;
+        bytes32 identityPrefix = hex"001122";
+        address sender = makeAddr("sender");
+        bytes memory encryptedTransaction = "aabbcc";
+        uint256 gasLimit = 8;
+
+        vm.expectEmit(address(sequencer));
+        emit TransactionSubmitted(
+            eon,
+            identityPrefix,
+            sender,
+            encryptedTransaction,
+            gasLimit
+        );
+
+        vm.fee(20);
+        hoax(sender);
+        sequencer.submitEncryptedTransaction{value: 160}(
+            eon,
+            identityPrefix,
+            encryptedTransaction,
+            gasLimit
+        );
+    }
+
+    function testSubmitTransactionInsufficientFee() public {
+        uint64 eon = 5;
+        bytes32 identityPrefix = hex"001122";
+        address sender = makeAddr("sender");
+        bytes memory encryptedTransaction = "aabbcc";
+        uint256 gasLimit = 8;
+
+        vm.expectRevert(InsufficientFee.selector);
+
+        vm.fee(20);
+        hoax(sender);
+        sequencer.submitEncryptedTransaction{value: 159}(
+            eon,
+            identityPrefix,
+            encryptedTransaction,
+            gasLimit
+        );
+    }
+
+    function testDecryptionProgressSubmitted() public {
+        bytes memory message = hex"aabbcc";
+        vm.expectEmit(address(sequencer));
+        emit DecryptionProgressSubmitted(message);
+        sequencer.submitDecryptionProgress(message);
+    }
+}


### PR DESCRIPTION
Implements the sequencer contract, as specified here: https://github.com/gnosischain/specs/blob/0cbe64223e67a2b47d0a7cfcd9d89c424d28374b/shutter/low-level.md#sequencer

The only difference is the sender argument in `submitEncryptedTransaction` which is an oversight in the spec and has to fixed there.